### PR TITLE
do not crash if voteLog is not found

### DIFF
--- a/library.js
+++ b/library.js
@@ -214,9 +214,8 @@ plugin.adminHeader = function (custom_header, callback) {
 function undoUpvote(user, author, post, callback) {
     //find extra vote value
     ReputationManager.findVoteLog(user, author, post, function (err, voteLog) {
-        if (err) {
-            callback(err);
-            return;
+        if (err || !voteLog) {
+            return callback(err);
         }
 
         var amount = voteLog.amount;
@@ -228,9 +227,8 @@ function undoUpvote(user, author, post, callback) {
 function undoDownvote(user, author, post, callback) {
     //find extra vote value
     ReputationManager.findVoteLog(user, author, post, function (err, voteLog) {
-        if (err) {
-            callback(err);
-            return;
+        if (err || !voteLog) {
+            return callback(err);
         }
 
         var amount = voteLog.amount;


### PR DESCRIPTION
Was getting this crash with this plugin
2018-03-06T18:03:21.374Z [29120] - ^[[31merror^[[39m:  TypeError: Cannot read property 'amount' of null
   at /node_modules/nodebb-plugin-reputation-rules/library.js:222:29