### PR TITLE
max downvotes per day #5

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -5,6 +5,7 @@ var MIN_POSTS_TO_UPVOTE = 20,
     MIN_REPUTATION_TO_DOWNVOTE = 10,
     MAX_VOTES_PER_USER_AND_THREAD = 5,
     MAX_VOTES_TO_SAME_USER_PER_MONTH = 1,
+    MAX_DOWNVOTES_PER_DAY = 5, // 0 means disabled
     UPVOTE_EXTRA_PERCENTAGE = 5,
     DOWNVOTE_EXTRA_PERCENTAGE = 5,
     DOWNVOTE_PENALIZATION = 1,
@@ -46,6 +47,9 @@ var Config = {
             calculatedVotesPerUser = MAX;
         }
         return calculatedVotesPerUser;
+    },
+    maxDownvotesPerDay: function () {
+        return MAX_DOWNVOTES_PER_DAY;
     },
     upvoteExtraPercentage: function () {
         return UPVOTE_EXTRA_PERCENTAGE;
@@ -97,6 +101,7 @@ var Config = {
         settings.minReputationToDownvote = MIN_REPUTATION_TO_DOWNVOTE;
         settings.maxVotesPerUserInThread = MAX_VOTES_PER_USER_AND_THREAD;
         settings.maxVotesToSameUserInMonth = MAX_VOTES_TO_SAME_USER_PER_MONTH;
+        settings.maxDownvotesPerDay = MAX_DOWNVOTES_PER_DAY;
         settings.upvoteExtraPercentage = UPVOTE_EXTRA_PERCENTAGE;
         settings.downvoteExtraPercentage = DOWNVOTE_EXTRA_PERCENTAGE;
         settings.downvotePenalization = DOWNVOTE_PENALIZATION;
@@ -115,6 +120,7 @@ var Config = {
         MIN_REPUTATION_TO_DOWNVOTE = settings.minReputationToDownvote;
         MAX_VOTES_PER_USER_AND_THREAD = settings.maxVotesPerUserInThread;
         MAX_VOTES_TO_SAME_USER_PER_MONTH = settings.maxVotesToSameUserInMonth;
+        MAX_DOWNVOTES_PER_DAY = settings.maxDownvotesPerDay;
         UPVOTE_EXTRA_PERCENTAGE = settings.upvoteExtraPercentage;
         DOWNVOTE_EXTRA_PERCENTAGE = settings.downvoteExtraPercentage;
         DOWNVOTE_PENALIZATION = settings.downvotePenalization;
@@ -133,4 +139,3 @@ function intArray(arr) {
 }
 
 module.exports = Config;
-

--- a/Config.js
+++ b/Config.js
@@ -86,6 +86,11 @@ var Config = {
         var today = now.getDate() + "-" + (now.getMonth() + 1) + "-" + now.getFullYear();
         return REP_LOG_NAMESPACE + ":user:" + voterId + ":day:" + today;
     },
+    getPerUserAndTypeLogId: function (voterId, voteType) {
+        var now = new Date();
+        var today = now.getDate() + "-" + (now.getMonth() + 1) + "-" + now.getFullYear();
+        return REP_LOG_NAMESPACE + ":user:" + voterId + ":day:" + today + ':type:' + voteType;
+    },
     getDisabledCategories: function () {
         return DISABLED_CATEGORIES_IDS;
     },

--- a/README.md
+++ b/README.md
@@ -6,49 +6,52 @@
 
 ![Screenshot](https://raw.githubusercontent.com/exo-do/nodebb-plugin-reputation-rules/master/reputation-rules-acp.png)
 
-### Rule #1 
+### Rule #1
 **Upvoting** In order to upvote, the user must have  
  - {MIN_POSTS_TO_UPVOTE} posts or more
  - at least {MIN_DAYS_TO_UPVOTE} days since registration
 
-### Rule #2 
+### Rule #2
 **Downvoting** In order to downvote, the user must have  
  - {MIN_POSTS_TO_DOWNVOTE} posts or more
  - at least {MIN_DAYS_TO_DOWNVOTE} since registration
  - {MIN_REPUTATION_TO_DOWNVOTE} reputation or more
 
-### Rule #3 
+### Rule #3
 Downvoting costs {DOWNVOTE_PENALIZATION} reputation (user who votes loses some reputation)
 
-### Rule #4 
+### Rule #4
 One user can't vote (up or down) more than `X` times a day, being `X = reputation/10`. With a minimum of 5 and a max of 50
 
-### Rule #5 
+### Rule #4.1
+One user can't downvote more than 5 times a day. Zero to disable this maximum
+
+### Rule #5
 Reputation can be disabled in certain subforums
 
-### Rule #6 
+### Rule #6
 A user cannot vote the same person twice in a month
 
-### Rule #7 
+### Rule #7
 A user cannot vote more than 5 messages in the same thread
 
-### Rule #8 
+### Rule #8
 Upvotes give extra reputation depending on the user who is voting:  
  - extra reputation = `floor(votersReputation * 5%)` (you can change this percentage in the ACP)
- 
+
 Downvotes decrease extra reputation depending on the user who is voting:  
  - extra reputation = `floor(votersReputation * 5%)` (you can change this percentage in the ACP)
 
-### Rule #9 
+### Rule #9
 Undoing votes:  
  - undoing an upvote should remove extra reputation awarded when upvote was given (extra rep should not be recalculated)
  - undoing a downvote should remove penalization to voter and give the extra reputation the author lost when he got the downvote
 
-### Rule #10 
+### Rule #10
 Upvotes and downvotes should have a maximum weigh, configurable. So that rule **#8** doesn't make vote points tend to infinity.
 
-### Rule #11 
-Optional: you can limit upvotes and downvotes to recent posts. In other words, if a message is too old, users won't be able to vote it. 
+### Rule #11
+Optional: you can limit upvotes and downvotes to recent posts. In other words, if a message is too old, users won't be able to vote it.
 You can configure what "too old" means for you, for example 30 days, 90 days, or 0 if you want to disable this feature and allow votes in old posts.  
 **Note** unvotes are always allowed.
 

--- a/ReputationManager.js
+++ b/ReputationManager.js
@@ -37,6 +37,7 @@ var ReputationManager = function (Config) {
 
         async.series([
                 userPermissions.votingAllowedInCategory,
+                userPermissions.hasDownvotedTooManyTimesToday,
                 userPermissions.hasEnoughPostsToDownvote,
                 userPermissions.isOldEnoughToDownvote,
                 userPermissions.hasEnoughReputationToDownvote,
@@ -165,9 +166,21 @@ var ReputationManager = function (Config) {
     }
 
     function saveUserVoteLog(vote, callback) {
-        var key = Config.getPerUserLogId(vote.voterId);
+        var userKey = Config.getPerUserLogId(vote.voterId);
+        var userAndVoteTypeKey = Config.getPerUserAndTypeLogId(vote.voterId, vote.type);
         var value = Config.getMainLogId(vote.voterId, vote.authorId, vote.topicId, vote.postId);
-        setAdd(key, value, callback);
+
+        async.series([
+                setAdd.bind(null, userKey, value),
+                setAdd.bind(null, userAndVoteTypeKey, value)
+            ],
+            function (err) {
+                if (err) {
+                    callback(err);
+                    return;
+                }
+                callback(null, vote);
+            });
     }
 
     function removeThreadVoteLog(vote, callback) {
@@ -183,9 +196,21 @@ var ReputationManager = function (Config) {
     }
 
     function removeUserVoteLog(vote, callback) {
-        var key = Config.getPerUserLogId(vote.voterId);
+        var userKey = Config.getPerUserLogId(vote.voterId);
+        var userAndVoteTypeKey = Config.getPerUserAndTypeLogId(vote.voterId, vote.type);
         var value = Config.getMainLogId(vote.voterId, vote.authorId, vote.topicId, vote.postId);
-        setRemove(key, value, callback);
+
+        async.series([
+                setRemove.bind(null, userKey, value),
+                setRemove.bind(null, userAndVoteTypeKey, value)
+            ],
+            function (err) {
+                if (err) {
+                    callback(err);
+                    return;
+                }
+                callback(null, vote);
+            });
     }
 
     function setAdd(key, value, callback) {

--- a/ReputationManager.js
+++ b/ReputationManager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var db = module.parent.parent.require('./database'),
+var db = require.main.require('./src/database'),
     async = require('async'),
     UserVotingPermissions = require('./UserVotingPermissions.js');
 

--- a/ReputationManager.js
+++ b/ReputationManager.js
@@ -197,12 +197,14 @@ var ReputationManager = function (Config) {
 
     function removeUserVoteLog(vote, callback) {
         var userKey = Config.getPerUserLogId(vote.voterId);
-        var userAndVoteTypeKey = Config.getPerUserAndTypeLogId(vote.voterId, vote.type);
+        var userUpvoteKey = Config.getPerUserAndTypeLogId(vote.voterId, 'upvote');
+        var userDownvoteKey = Config.getPerUserAndTypeLogId(vote.voterId, 'downvote');
         var value = Config.getMainLogId(vote.voterId, vote.authorId, vote.topicId, vote.postId);
 
         async.series([
                 setRemove.bind(null, userKey, value),
-                setRemove.bind(null, userAndVoteTypeKey, value)
+                setRemove.bind(null, userUpvoteKey, value),
+                setRemove.bind(null, userDownvoteKey, value)
             ],
             function (err) {
                 if (err) {

--- a/ReputationParams.js
+++ b/ReputationParams.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var async = require('async'),
-    User = module.parent.parent.require('./user'),
-    Posts = module.parent.parent.require('./posts');
+    User = require.main.require('./src/user'),
+    Posts = require.main.require('./src/posts');
 
 var ReputationParams = function (userId, postId) {
     var _this = this;

--- a/VoteFilter.js
+++ b/VoteFilter.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var winston = require('winston'),
+var winston = require.main.require('winston'),
     ReputationParams = require('./ReputationParams'),
     translator = require('./translator');
 

--- a/library.js
+++ b/library.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var plugin = {'settingsVersion': '1.1.2'},
-    db = module.parent.require('./database'),
-    users = module.parent.require('./user'),
-    meta = module.parent.require('./meta'),
-    Settings = module.parent.require('./settings'),
-    SocketAdmin = module.parent.require('./socket.io/admin'),
+var plugin = {'settingsVersion': '1.1.3'},
+    db = require.main.require('./src/database'),
+    users = require.main.require('./src/user'),
+    meta = require.main.require('./src/meta'),
+    Settings = require.main.require('./src/settings'),
+    SocketAdmin = require.main.require('./src/socket.io/admin'),
 
-    winston = require('winston'),
+    winston = require.main.require('winston'),
 
     ReputationParams = require('./ReputationParams'),
     VoteLog = require('./VoteLog'),
@@ -285,7 +285,7 @@ function banUserForLowReputation(uid, newreputation) {
             if (err || parseInt(banned, 10) === 1) {
                 return;
             }
-            var adminUser = module.parent.require('./socket.io/admin/user');
+            var adminUser = require.main.require('./src/socket.io/admin/user');
             adminUser.banUser(uid, function (err) {
                 if (err) {
                     return winston.error(err.message);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "readmeFilename": "README.md",
   "nbbpm": {
-    "compatibility": "^1.0.x || ^1.1.x"
+    "compatibility": "^1.13.0"
+  },
+  "dependencies": {
+    "async": "^2"
   }
 }

--- a/public/languages/en_GB/nodebb-plugin-reputation-rules.json
+++ b/public/languages/en_GB/nodebb-plugin-reputation-rules.json
@@ -6,6 +6,7 @@
   "tooManyVotesInThread": "You can't vote more messages in this thread",
   "tooManyVotesToSameUserThisMonth": "You can't vote this user again until next month",
   "tooManyVotesToday": "You can't vote more messages today",
+  "tooManyDownvotesToday": "You can't downvote more messages today",
   "postTooOld": "You can't vote this message, it is too old",
   "unknownError": "Error voting"
 }

--- a/public/languages/es/nodebb-plugin-reputation-rules.json
+++ b/public/languages/es/nodebb-plugin-reputation-rules.json
@@ -6,6 +6,7 @@
   "tooManyVotesInThread": "No puedes votar más mensajes en este hilo",
   "tooManyVotesToSameUserThisMonth": "Ya has votado a este usuario este mes",
   "tooManyVotesToday": "No puedes votar más mensajes hoy",
+  "tooManyDownvotesToday": "No puedes dar más negativos hoy",
   "postTooOld": "No puedes votar este mensaje, es muy antiguo",
   "unknownError": "Error al votar"
 }

--- a/public/templates/admin/plugins/reputation-rules.tpl
+++ b/public/templates/admin/plugins/reputation-rules.tpl
@@ -112,6 +112,13 @@
                     <input class="form-control" type="number" data-key="maxDownvoteWeigh" title="Max downvote points">
                     <br>
                 </div>
+
+                <div class="form-group">
+                    <!-- (MAX_DOWNVOTES_PER_DAY) -->
+                    <label>Max downvotes per user and day (0 to allow unlimited downvotes per day):</label>
+                    <input class="form-control" type="number" data-key="maxDownvotesPerDay" title="Max downvotes per day">
+                    <br>
+                </div>
             </div>
         </div>
 
@@ -176,11 +183,11 @@
 require(['settings'], function(settings) {
 
     settings.sync('reputation-rules', $('#reputation-rules'));
-    
+
     $('#reset').click( function (event) {
         $('#reputation-rules')[0].reset();
     });
-    
+
     $('#clear').click( function (event) {
         $('#reputation-rules').find('input').val('');
     });


### PR DESCRIPTION
Added a new rule, optional (set it to zero to disable it), that allows you to limit the number of times a user can downvote per day.
By default it is 5 downvotes per day.

I've had to update a few other things because the plugin was not compatible with v1.13.0 and I have fixed all warnings too.

This closes #5 